### PR TITLE
Add CX-50 odometer signal (header 0x723)

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -35,6 +35,10 @@
   "signals": [
     {"id": "CX3_FLV", "path": "Fuel", "fmt": { "len": 8, "max": 255, "unit": "liters" }, "name": "Fuel level", "suggestedMetric": "fuelTankLevel"}
   ]},
+{ "hdr": "723", "rax": "72B", "cmd": {"22": "DD01"}, "freq": 1, "dbgfilter": { "to": 2016, "years": [2018], "from": 2020 },
+  "signals": [
+    {"id": "CX3_ODO", "path": "Trips", "fmt": { "len": 24, "max": 16777215, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
+  ]},
 { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "0301"}, "freq": 0.25, "dbgfilter": { "to": 2016, "years": [2018], "from": 2020 },
   "signals": [
     {"id": "CX3_MAP", "path": "Engine", "fmt": { "len": 16, "max": 4, "div": 1000, "unit": "volts" }, "name": "Manifold absolute pressure voltage", "description": "A properly functioning sensor should read around 1 to 1.5 volts at idle."}

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -35,7 +35,7 @@
   "signals": [
     {"id": "CX3_FLV", "path": "Fuel", "fmt": { "len": 8, "max": 255, "unit": "liters" }, "name": "Fuel level", "suggestedMetric": "fuelTankLevel"}
   ]},
-{ "hdr": "723", "rax": "72B", "cmd": {"22": "DD01"}, "freq": 1, "dbgfilter": { "to": 2016, "years": [2018], "from": 2020 },
+{ "hdr": "723", "rax": "72B", "dbg": true, "cmd": {"22": "DD01"}, "freq": 1,
   "signals": [
     {"id": "CX3_ODO", "path": "Trips", "fmt": { "len": 24, "max": 16777215, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
   ]},


### PR DESCRIPTION
Adds odometer signal from CX-50 to test if the instrument cluster (header 0x723) responds on CX-3.

**Details:**
- Header: `0x723` (instrument cluster)
- Response: `0x72B`
- Command: `22 DD01`
- Signal: `CX3_ODO`
- Format: 24-bit value (max 16,777,215 km)
- Path: `Trips`
- suggestedMetric: `odometer`

**Testing:**
If the instrument cluster responds, this will provide true odometer readings for CX-3.